### PR TITLE
Despliegue en heroku

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,3 +1,4 @@
+STAGE=dev
 
 # DB
 DB_PASSWORD=ñsodjñlkvdmf123M

--- a/package.json
+++ b/package.json
@@ -5,14 +5,17 @@
   "author": "",
   "private": true,
   "license": "UNLICENSED",
+  "engines": {
+    "node": "17.x"
+  },
   "scripts": {
     "prebuild": "rimraf dist",
     "build": "nest build",
     "format": "prettier --write \"src/**/*.ts\" \"test/**/*.ts\"",
-    "start": "nest start",
+    "start": "node dist/main",
     "start:dev": "nest start --watch",
     "start:debug": "nest start --debug --watch",
-    "start:prod": "node dist/main",
+    "start:prod": "nest start",
     "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
     "test": "jest",
     "test:watch": "jest --watch",

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,11 @@ import { MessageWsModule } from './message-ws/message-ws.module';
   imports: [
     ConfigModule.forRoot(),
     TypeOrmModule.forRoot({
+      ssl: process.env.STAGE === 'prod', // necesario para una conexion certificada self-sign certificate
+      extra: {
+        ssl:
+          process.env.STAGE === 'prod' ? { rejectUnauthorized: false } : null, // necesario para una conexion certificada
+      },
       type: 'postgres',
       host: process.env.DB_HOST,
       port: +process.env.DB_PORT,


### PR DESCRIPTION
Cambios necesarios para poder hacer el deploy en heroku

- especificacion de version de node
- cambios relacionados a ssl en TypeOrmModule.forRoot()
- agregado de STAGE en .env
- cambio de script para que heroku ejecute el codigo correspondiente a start:dev en vez del correspondiente a start